### PR TITLE
Bumping Flink version to 1.17.0

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <maven.javadoc.skip>false</maven.javadoc.skip>
         <questdb.version>6.6.1</questdb.version>
-        <flink.version>1.16.1</flink.version>
+        <flink.version>1.17.0</flink.version>
         <testcontainers.version>1.17.3</testcontainers.version>
         <httpclient.version>4.5.14</httpclient.version>
         <maven.compiler.source>11</maven.compiler.source>

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@ Sink data from [Apache Flink](https://flink.apache.org/) pipelines to [QuestDB](
 
 The connector implements Apache Flink [Table / SQL API](https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/connectors/table/overview/). 
 
-It has been tested to work with Flink versions 1.15 and 1.16.
+It has been tested to work with Flink versions 1.15, 1.16, and 1.17.
 
 ## Usage with Flink SQL
 _This guide assumes you are already familiar with Apache Flink. Please see [Flink Documentation](https://nightlies.apache.org/flink/flink-docs-release-1.15//docs/try-flink/local_installation/) to learn Flink Basics or check our [sample projects](samples)._

--- a/samples/coinbase-to-kafka-to-questdb/pom.xml
+++ b/samples/coinbase-to-kafka-to-questdb/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scala.binary.version>2.12</scala.binary.version>
-        <flink.version>1.16.1</flink.version>
+        <flink.version>1.17.0</flink.version>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>

--- a/samples/datagen-to-questdb/pom.xml
+++ b/samples/datagen-to-questdb/pom.xml
@@ -11,7 +11,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scala.binary.version>2.12</scala.binary.version>
-        <flink.version>1.16.1</flink.version>
+        <flink.version>1.17.0</flink.version>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>


### PR DESCRIPTION
Flink 1.17.0 was just released and we are compatible with it. Bumping version on the connector and samples